### PR TITLE
fixed bad reference to a not existing editorView

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -61,7 +61,7 @@ handleBufferEvents = (editorView) ->
         console.log e
 
 lint = (editorView = atom.workspaceView.getActiveView()) ->
-  return if editorView.coffeeLintPending
+  return if editorView?.coffeeLintPending
   {editor, gutter} = editorView
   return unless editor
   isCoffeeFile = editor.getGrammar().scopeName is "source.coffee"


### PR DESCRIPTION
When closing several coffeescript files very fast, the last one is closed before the pending method can be called on it. Asking for existence does the trick here, while the editor view itself is checked 2 lines later explicitly.
