### PR TITLE
Lets use atom.project.getPath() because of .path was private property for Project class

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -73,7 +73,7 @@ lint = (editorView = atom.workspaceView.getActiveView()) ->
   gutter.find('.line-number .icon-right').attr 'title', ''
   source = editor.getText()
   try
-    localFile = path.join atom.project.path, 'coffeelint.json'
+    localFile = path.join atom.project.getPath(), 'coffeelint.json'
     configObject = {}
     if fs.existsSync localFile
       configObject = fs.readFileSync localFile, 'UTF8'


### PR DESCRIPTION
[issues/5613](https://github.com/atom/atom/issues/5613)

Now if you open web developer tools you will see on opened coffee files the errors. The fix should remove the errors.
